### PR TITLE
Fixing CI management URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
 
         <ciManagement>
             <system>Jenkins CI</system>
-            <url>http://clinker.datasalt.com/jenkins/view/Splout-db/</url>
+            <url>http://clinker.datasalt.com/jenkins/view/SploutSQL</url>
         </ciManagement>
 
 	<scm>


### PR DESCRIPTION
The CI management URL was pointing to an old Jenkins view
